### PR TITLE
Add support for OS X

### DIFF
--- a/BigBoard.podspec
+++ b/BigBoard.podspec
@@ -29,7 +29,7 @@ BigBoard is an elegant financial markets library for iOS written in Swift. Under
 
     s.source_files = 'Pod/Classes/**/*'
 
-    s.platform = :ios
+    s.osx.deployment_target = '10.11'
     s.ios.deployment_target = '9.0'
 
     s.dependency 'AlamofireObjectMapper', '~> 4.0'

--- a/Pod/Classes/UIImageView+BigBoard.swift
+++ b/Pod/Classes/UIImageView+BigBoard.swift
@@ -16,6 +16,10 @@
  
 */
 
+// UIKit is only available in iOS, not on OSX.
+// Do not import this file if platform is OSX
+
+#if os(iOS)
 import UIKit
 import Alamofire
 import AlamofireImage
@@ -52,3 +56,4 @@ public extension UIImageView {
         }
     }
 }
+#endif


### PR DESCRIPTION
I don't see why this library should be restricted only to iOS. So I added support for OS X also. 

Since UIKit is not present on OSX, I updated `Pod/Classes/UIImageView+BigBoard.swift` file to make it iOS specific. Swift beginner here, not sure if that is correct. 

After these changes, I installed Bigboard in my OSX app and it works 😅 